### PR TITLE
PES-3334 : fix: update extraction of alias from sql file

### DIFF
--- a/adapters/integrations/gitlab-integration.js
+++ b/adapters/integrations/gitlab-integration.js
@@ -781,16 +781,16 @@ ${content}`;
         );
         const startRegex =
             /{{\s*config\s*\(/im;
-        const startMatch = fileContent.match(startRegex);
+        const startMatch = fileContents.match(startRegex);
         let configSection = ''
         if (startMatch) {
             const startIndex = startMatch.index;
-            const openParensIndex = fileContent.indexOf('(', startIndex) + 1;
+            const openParensIndex = fileContents.indexOf('(', startIndex) + 1;
             let openParensCount = 1;
             let endIndex = openParensIndex;
 
-            while (openParensCount > 0 && endIndex < fileContent.length) {
-                const char = fileContent[endIndex];
+            while (openParensCount > 0 && endIndex < fileContents.length) {
+                const char = fileContents[endIndex];
 
                 if (char === '(') {
                     openParensCount++;
@@ -802,9 +802,9 @@ ${content}`;
             }
 
             const endMarker = '}}';
-            const finalEndIndex = fileContent.indexOf(endMarker, endIndex) + endMarker.length;
+            const finalEndIndex = fileContents.indexOf(endMarker, endIndex) + endMarker.length;
 
-            configSection = fileContent.substring(startIndex, finalEndIndex);
+            configSection = fileContents.substring(startIndex, finalEndIndex);
             logger.withInfo(
               "Extracted config section",
               integrationName,

--- a/adapters/integrations/gitlab-integration.js
+++ b/adapters/integrations/gitlab-integration.js
@@ -779,23 +779,67 @@ ${content}`;
           CI_COMMIT_SHA,
           "getAssetName"
         );
-        var matches = regExp.exec(fileContents);
+        const startRegex =
+            /{{\s*config\s*\(/im;
+        const startMatch = fileContent.match(startRegex);
+        let configSection = ''
+        if (startMatch) {
+            const startIndex = startMatch.index;
+            const openParensIndex = fileContent.indexOf('(', startIndex) + 1;
+            let openParensCount = 1;
+            let endIndex = openParensIndex;
 
-        logger.withInfo(
-          "Successfully executed regex matching",
-          integrationName,
-          CI_COMMIT_SHA,
-          "getAssetName"
-        );
+            while (openParensCount > 0 && endIndex < fileContent.length) {
+                const char = fileContent[endIndex];
 
-        if (matches) {
-          logger.withInfo(
-            `Found a match: ${matches[1].trim()}`,
-            integrationName,
-            CI_COMMIT_SHA,
-            "getAssetName"
-          );
-          return matches[1].trim();
+                if (char === '(') {
+                    openParensCount++;
+                } else if (char === ')') {
+                    openParensCount--;
+                }
+
+                endIndex++;
+            }
+
+            const endMarker = '}}';
+            const finalEndIndex = fileContent.indexOf(endMarker, endIndex) + endMarker.length;
+
+            configSection = fileContent.substring(startIndex, finalEndIndex);
+            logger.withInfo(
+              "Extracted config section",
+              integrationName,
+              CI_COMMIT_SHA,
+              "getAssetName"
+            );
+
+            if (configSection){
+                logger.withInfo(
+                  "Executing final regex",
+                  integrationName,
+                  CI_COMMIT_SHA,
+                  "getAssetName"
+                );
+
+                var matches = regExp.exec(configSection);
+
+                logger.withInfo(
+                  "Successfully executed regex matching",
+                  integrationName,
+                  CI_COMMIT_SHA,
+                  "getAssetName"
+                );
+
+            }
+            if (matches) {
+              logger.withInfo(
+                `Found a match: ${matches[1].trim()}`,
+                integrationName,
+                CI_COMMIT_SHA,
+                "getAssetName"
+              );
+
+              return matches[1].trim();
+            }
         }
       }
 

--- a/adapters/integrations/gitlab-integration.js
+++ b/adapters/integrations/gitlab-integration.js
@@ -784,23 +784,22 @@ ${content}`;
         const startMatch = fileContents.match(startRegex);
         let configSection = ''
         if (startMatch) {
-            const startIndex = startMatch.index;
-            const openParensIndex = fileContents.indexOf('(', startIndex) + 1;
-            let openParensCount = 1;
-            let endIndex = openParensIndex;
+          const startIndex = startMatch.index;
+          const openParensIndex = fileContents.indexOf('(', startIndex) + 1;
+          let openParensCount = 1;
+          let endIndex = openParensIndex;
 
-            while (openParensCount > 0 && endIndex < fileContents.length) {
-                const char = fileContents[endIndex];
+          while (openParensCount > 0 && endIndex < fileContents.length) {
+            const char = fileContents[endIndex];
 
-                if (char === '(') {
-                    openParensCount++;
-                } else if (char === ')') {
-                    openParensCount--;
-                }
-
-                endIndex++;
+            if (char === '(') {
+                openParensCount++;
+            } else if (char === ')') {
+                openParensCount--;
             }
-
+            endIndex++;
+            }
+            
             const endMarker = '}}';
             const finalEndIndex = fileContents.indexOf(endMarker, endIndex) + endMarker.length;
 
@@ -813,21 +812,21 @@ ${content}`;
             );
 
             if (configSection){
-                logger.withInfo(
-                  "Executing final regex",
-                  integrationName,
-                  CI_COMMIT_SHA,
-                  "getAssetName"
-                );
+              logger.withInfo(
+                "Executing final regex",
+                integrationName,
+                CI_COMMIT_SHA,
+                "getAssetName"
+              );
 
-                var matches = regExp.exec(configSection);
+              var matches = regExp.exec(configSection);
 
-                logger.withInfo(
-                  "Successfully executed regex matching",
-                  integrationName,
-                  CI_COMMIT_SHA,
-                  "getAssetName"
-                );
+              logger.withInfo(
+                "Successfully executed regex matching",
+                integrationName,
+                CI_COMMIT_SHA,
+                "getAssetName"
+              );
 
             }
             if (matches) {

--- a/dist/index.js
+++ b/dist/index.js
@@ -34803,23 +34803,66 @@ ${content}`;
           CI_COMMIT_SHA,
           "getAssetName"
         );
-        var matches = regExp.exec(fileContents);
+        const startRegex =
+            /{{\s*config\s*\(/im;
+        const startMatch = fileContents.match(startRegex);
+        let configSection = ''
+        if (startMatch) {
+          const startIndex = startMatch.index;
+          const openParensIndex = fileContents.indexOf('(', startIndex) + 1;
+          let openParensCount = 1;
+          let endIndex = openParensIndex;
 
-        logger_logger.withInfo(
-          "Successfully executed regex matching",
-          gitlab_integration_integrationName,
-          CI_COMMIT_SHA,
-          "getAssetName"
-        );
+          while (openParensCount > 0 && endIndex < fileContents.length) {
+            const char = fileContents[endIndex];
 
-        if (matches) {
-          logger_logger.withInfo(
-            `Found a match: ${matches[1].trim()}`,
-            gitlab_integration_integrationName,
-            CI_COMMIT_SHA,
-            "getAssetName"
-          );
-          return matches[1].trim();
+            if (char === '(') {
+                openParensCount++;
+            } else if (char === ')') {
+                openParensCount--;
+            }
+            endIndex++;
+            }
+            
+            const endMarker = '}}';
+            const finalEndIndex = fileContents.indexOf(endMarker, endIndex) + endMarker.length;
+
+            configSection = fileContents.substring(startIndex, finalEndIndex);
+            logger_logger.withInfo(
+              "Extracted config section",
+              gitlab_integration_integrationName,
+              CI_COMMIT_SHA,
+              "getAssetName"
+            );
+
+            if (configSection){
+              logger_logger.withInfo(
+                "Executing final regex",
+                gitlab_integration_integrationName,
+                CI_COMMIT_SHA,
+                "getAssetName"
+              );
+
+              var matches = regExp.exec(configSection);
+
+              logger_logger.withInfo(
+                "Successfully executed regex matching",
+                gitlab_integration_integrationName,
+                CI_COMMIT_SHA,
+                "getAssetName"
+              );
+
+            }
+            if (matches) {
+              logger_logger.withInfo(
+                `Found a match: ${matches[1].trim()}`,
+                gitlab_integration_integrationName,
+                CI_COMMIT_SHA,
+                "getAssetName"
+              );
+
+              return matches[1].trim();
+            }
         }
       }
 


### PR DESCRIPTION
The original regex can take too long to execute. Extracting the config first and then running it would be much more efficient.

Jira: https://atlanhq.atlassian.net/browse/PES-3334