### PR TITLE
PES-3558 : fix: update extraction of alias from sql file

### DIFF
--- a/dist/index.js
+++ b/dist/index.js
@@ -26179,24 +26179,90 @@ class GitHubIntegration extends IntegrationInterface {
         filePath,
       });
 
+      logger_logger.withInfo(
+        `Successfully fetched file contents. File size: ${fileContents.length} bytes`,
+        integrationName,
+        headSHA,
+        "getAssetName"
+      );      
+
       if (fileContents) {
-        var matches = regExp.exec(fileContents);
-        if (matches) {
-          logger_logger.withInfo(
-            `Found a match: ${matches[1].trim()}`,
-            integrationName,
-            headSHA,
-            "getAssetName"
-          );
-          return matches[1].trim();
+        logger_logger.withInfo(
+          "Starting regex matching",
+          integrationName,
+          headSHA,
+          "getAssetName"
+        );
+        const startRegex =
+            /{{\s*config\s*\(/im;
+        const startMatch = fileContents.match(startRegex);
+        let configSection = ''
+        if (startMatch) {
+          const startIndex = startMatch.index;
+          const openParensIndex = fileContents.indexOf('(', startIndex) + 1;
+          let openParensCount = 1;
+          let endIndex = openParensIndex;
+
+          while (openParensCount > 0 && endIndex < fileContents.length) {
+            const char = fileContents[endIndex];
+
+            if (char === '(') {
+                openParensCount++;
+            } else if (char === ')') {
+                openParensCount--;
+            }
+            endIndex++;
+            }
+            
+            const endMarker = '}}';
+            const finalEndIndex = fileContents.indexOf(endMarker, endIndex) + endMarker.length;
+
+            configSection = fileContents.substring(startIndex, finalEndIndex);
+            logger_logger.withInfo(
+              "Extracted config section",
+              integrationName,
+              headSHA,
+              "getAssetName"
+            );
+
+            if (configSection){
+              logger_logger.withInfo(
+                "Executing final regex",
+                integrationName,
+                headSHA,
+                "getAssetName"
+              );
+
+              var matches = regExp.exec(configSection);
+
+              logger_logger.withInfo(
+                "Successfully executed regex matching",
+                integrationName,
+                headSHA,
+                "getAssetName"
+              );
+
+            }
+            if (matches) {
+              logger_logger.withInfo(
+                `Found a match: ${matches[1].trim()}`,
+                integrationName,
+                headSHA,
+                "getAssetName"
+              );
+
+              return matches[1].trim();
+            }
         }
       }
+
       logger_logger.withInfo(
         `Using filename as asset name: ${fileName}`,
         integrationName,
         headSHA,
         "getAssetName"
       );
+
       return fileName;
     } catch (error) {
       logger_logger.withError(


### PR DESCRIPTION
The original regex can take too long to execute. Extracting the config first and then running it would be much more efficient.
Same fix was made for gitlab integration here: https://github.com/atlanhq/dbt-action/pull/129

Jira: https://atlanhq.atlassian.net/browse/PES-3558

Have tested the action on my fork of this repo with this fix here: https://github.com/sharma-shreyas/dbt-action/pull/10
(used the customer's failing sql files)