### PR TITLE
chore: enable dep-cooldown blocking check

### DIFF
--- a/.github/workflows/dep-cooldown.yml
+++ b/.github/workflows/dep-cooldown.yml
@@ -22,3 +22,6 @@ jobs:
     uses: atlanhq/.github/.github/workflows/reusable-dep-cooldown.yml@main
     with:
       min-age-days: 7
+    # Forwards the org-level SLACK_DEP_COOLDOWN_WEBHOOK secret to the reusable
+    # workflow so it can post failure alerts to #community-security.
+    secrets: inherit

--- a/.github/workflows/dep-cooldown.yml
+++ b/.github/workflows/dep-cooldown.yml
@@ -19,6 +19,6 @@ permissions:
 
 jobs:
   cooldown:
-    uses: atlanhq/.github/.github/workflows/reusable-dep-cooldown.yml@97063f1c0966f11422a1c7d7d5c0deb40abf1291 # 2026-04-29 hardened
+    uses: atlanhq/.github/.github/workflows/reusable-dep-cooldown.yml@main
     with:
       min-age-days: 7

--- a/.github/workflows/dep-cooldown.yml
+++ b/.github/workflows/dep-cooldown.yml
@@ -1,0 +1,23 @@
+name: dep-cooldown
+
+# Calls the org-shared cooldown checker in atlanhq/.github (PR #31, hardened in #33).
+# Fails the PR if any newly-introduced dependency version is younger than 7 days.
+# Bypass: add the 'security' label to the PR (use only for urgent CVE patches).
+#
+# This file is uniform across every repo. To change policy, edit the
+# reusable workflow in atlanhq/.github and bump the SHA below.
+
+on:
+  pull_request:
+    types: [opened, synchronize, reopened, labeled, unlabeled]
+    branches: [main]
+
+permissions:
+  contents: read
+  pull-requests: read
+
+jobs:
+  cooldown:
+    uses: atlanhq/.github/.github/workflows/reusable-dep-cooldown.yml@97063f1c0966f11422a1c7d7d5c0deb40abf1291 # 2026-04-29 hardened
+    with:
+      min-age-days: 7

--- a/.github/workflows/dep-cooldown.yml
+++ b/.github/workflows/dep-cooldown.yml
@@ -8,9 +8,10 @@ name: dep-cooldown
 # reusable workflow in atlanhq/.github and bump the SHA below.
 
 on:
+  # Trigger on every PR regardless of base branch. Some repos use master /
+  # staging / develop as default; hardcoding 'main' would silently skip them.
   pull_request:
     types: [opened, synchronize, reopened, labeled, unlabeled]
-    branches: [main]
 
 permissions:
   contents: read


### PR DESCRIPTION
Adds the org-shared **dep-cooldown** CI check to this repo.

## What it does
On every PR that modifies (or doesn't) a lockfile, the check runs in <15 seconds. If the PR introduces any dep version published less than 7 days ago, the check fails. Pairs with the org-level branch ruleset (currently in evaluate mode) — once that ruleset goes active for this repo, fresh-dep PRs will be blocked from merging.

## Why we're doing this
Manual `npm install some-fresh-package` and committing the lockfile is a documented attack vector — it bypasses Renovate-style automation gates. Cooldown is the cheapest defense and applies uniformly across npm / pnpm / yarn lockfiles.

## What you need to do
- **Nothing** for normal flow. The check just runs alongside your existing CI.
- If a CVE patch needs to fast-track, add the `security` label to the PR — cooldown is skipped for that PR.

## Where the policy lives
Reusable workflow in `atlanhq/.github`, pinned to a specific SHA in this file. Bumping the SHA is a deliberate review action.

## Reference
- Reusable workflow: `atlanhq/.github` PR #31 (initial) + #33 (security hardening)
- First consumer: `atlanhq/Security-Automations` PR #19 (production proof of working check)